### PR TITLE
Add Ollama code assistant server and VSCode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ Then install the extension dependencies and launch the extension host from the
 npm install
 ```
 
-Run the **Ask Ollama Assistant** command to query the model with the selected
-code.
+Run the **Ask Ollama Assistant** command and enter a question when prompted to
+query the model with the selected code.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,26 @@ agent = create_dataframe_agent(df, llm, verbose=True)
 response = query_dataframe(agent, "What is the average value in column A?")
 print(response)
 ```
+
+## VSCode Coding Assistant
+
+The `code_assistant_server.py` module exposes a FastAPI server that can answer
+questions about code snippets using an Ollama LLM. A minimal VSCode extension
+located in `vscode-extension/` sends the selected code to this server and shows
+the response in an output channel.
+
+Start the API server:
+
+```bash
+python code_assistant_server.py
+```
+
+Then install the extension dependencies and launch the extension host from the
+`vscode-extension` folder:
+
+```bash
+npm install
+```
+
+Run the **Ask Ollama Assistant** command to query the model with the selected
+code.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ print(response)
 ## VSCode Coding Assistant
 
 The `code_assistant_server.py` module exposes a FastAPI server that can answer
-questions about code snippets using an Ollama LLM. A minimal VSCode extension
-located in `vscode-extension/` sends the selected code to this server and shows
-the response in an output channel.
+questions about code snippets using an Ollama LLM. A VSCode extension in
+`vscode-extension/` sends the selected code to this server and displays the
+assistant's answers in an interactive chat panel.
 
 Start the API server:
 
@@ -48,5 +48,5 @@ Then install the extension dependencies and launch the extension host from the
 npm install
 ```
 
-Run the **Ask Ollama Assistant** command and enter a question when prompted to
-query the model with the selected code.
+Run the **Ask Ollama Assistant** command to open the chat panel. Enter questions
+to query the model with the currently selected code.

--- a/code_assistant_server.py
+++ b/code_assistant_server.py
@@ -1,0 +1,30 @@
+"""Simple API server exposing an Ollama-powered code assistant."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from pandas_ollama_agent import create_ollama_llm
+from langchain.schema import HumanMessage
+
+app = FastAPI()
+llm = create_ollama_llm()
+
+
+class Query(BaseModel):
+    code: str
+    question: str | None = None
+
+
+@app.post("/query")
+async def query_code(data: Query):
+    prompt = data.question or "Please review the following code:"\
+        + "\n" + data.code
+    messages = [HumanMessage(content=prompt)]
+    response = llm.invoke(messages)
+    # LangChain returns a ChatMessage object with content
+    return {"answer": response.content}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ langchain-community
 langchain-experimental
 tabulate
 pytest
+fastapi
+uvicorn

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -2,7 +2,8 @@
 
 This extension sends the selected code from the editor to a local API
 (`http://localhost:8000/query`) that uses an Ollama language model.
-The response is displayed in an output channel.
+When you run the command you'll be asked to provide a question for the
+assistant. The response is displayed in an output channel.
 
 ## Development
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -2,8 +2,8 @@
 
 This extension sends the selected code from the editor to a local API
 (`http://localhost:8000/query`) that uses an Ollama language model.
-When you run the command you'll be asked to provide a question for the
-assistant. The response is displayed in an output channel.
+When you run the command a chat panel opens where you can enter questions and
+see the assistant's responses.
 
 ## Development
 
@@ -15,5 +15,6 @@ npm install
 
 2. Launch the extension in the Extension Development Host.
 
-3. Ensure the Python API server is running before executing the command
-   **Ask Ollama Assistant** from the command palette.
+3. Ensure the Python API server is running. Execute the
+   **Ask Ollama Assistant** command from the command palette to open the chat
+   panel and start interacting with the assistant.

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,18 @@
+# Ollama Code Assistant VSCode Extension
+
+This extension sends the selected code from the editor to a local API
+(`http://localhost:8000/query`) that uses an Ollama language model.
+The response is displayed in an output channel.
+
+## Development
+
+1. Install the dependencies:
+
+```bash
+npm install
+```
+
+2. Launch the extension in the Extension Development Host.
+
+3. Ensure the Python API server is running before executing the command
+   **Ask Ollama Assistant** from the command palette.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,8 +9,18 @@ async function askAssistant() {
   }
   const selection = editor.selection;
   const text = editor.document.getText(selection.isEmpty ? undefined : selection);
+  const question = await vscode.window.showInputBox({
+    prompt: 'Enter your question for the assistant (leave empty to explain the code)'
+  });
+  if (question === undefined) {
+    // User canceled the input box
+    return;
+  }
   try {
-    const response = await axios.post('http://localhost:8000/query', { code: text });
+    const response = await axios.post('http://localhost:8000/query', {
+      code: text,
+      question: question || null,
+    });
     const output = response.data.answer || response.data;
     const channel = vscode.window.createOutputChannel('Ollama Assistant');
     channel.appendLine(output);

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,43 +1,87 @@
 const vscode = require('vscode');
 const axios = require('axios');
 
-async function askAssistant() {
+let panel;
+
+function getWebviewContent() {
+  return `<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      body { font-family: sans-serif; }
+      #messages { height: 80vh; overflow-y: auto; }
+      .msg { margin: 4px 0; }
+    </style>
+  </head>
+  <body>
+    <div id="messages"></div>
+    <input id="input" type="text" placeholder="Ask a question" />
+    <script>
+      const vscode = acquireVsCodeApi();
+      const input = document.getElementById('input');
+      function addMessage(role, text) {
+        const container = document.getElementById('messages');
+        const div = document.createElement('div');
+        div.className = 'msg';
+        div.textContent = (role === 'user' ? 'You: ' : 'Assistant: ') + text;
+        container.appendChild(div);
+        container.scrollTop = container.scrollHeight;
+      }
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          const text = input.value;
+          input.value = '';
+          vscode.postMessage({ command: 'ask', text });
+          addMessage('user', text);
+        }
+      });
+      window.addEventListener('message', event => {
+        addMessage('assistant', event.data.text);
+      });
+    </script>
+  </body>
+  </html>`;
+}
+
+async function queryAssistant(question) {
   const editor = vscode.window.activeTextEditor;
-  if (!editor) {
-    vscode.window.showErrorMessage('No active editor.');
-    return;
-  }
-  const selection = editor.selection;
-  const text = editor.document.getText(selection.isEmpty ? undefined : selection);
-  const question = await vscode.window.showInputBox({
-    prompt: 'Enter your question for the assistant (leave empty to explain the code)'
-  });
-  if (question === undefined) {
-    // User canceled the input box
-    return;
-  }
+  const text = editor ? editor.document.getText(editor.selection.isEmpty ? undefined : editor.selection) : '';
   try {
     const response = await axios.post('http://localhost:8000/query', {
       code: text,
-      question: question || null,
+      question,
     });
-    const output = response.data.answer || response.data;
-    const channel = vscode.window.createOutputChannel('Ollama Assistant');
-    channel.appendLine(output);
-    channel.show();
+    return response.data.answer || response.data;
   } catch (err) {
-    vscode.window.showErrorMessage('Request failed: ' + err.message);
+    return 'Request failed: ' + err.message;
   }
 }
 
+function createOrShowPanel() {
+  if (panel) {
+    panel.reveal(vscode.ViewColumn.Beside);
+    return panel;
+  }
+  panel = vscode.window.createWebviewPanel('ollamaAssistant', 'Ollama Assistant', vscode.ViewColumn.Beside, { enableScripts: true });
+  panel.webview.html = getWebviewContent();
+  panel.onDidDispose(() => { panel = undefined; });
+  panel.webview.onDidReceiveMessage(async message => {
+    if (message.command === 'ask') {
+      const answer = await queryAssistant(message.text);
+      panel.webview.postMessage({ text: answer });
+    }
+  });
+  return panel;
+}
+
 function activate(context) {
-  let disposable = vscode.commands.registerCommand('ollamaCodeAssistant.ask', askAssistant);
+  const disposable = vscode.commands.registerCommand('ollamaCodeAssistant.ask', () => {
+    createOrShowPanel();
+  });
   context.subscriptions.push(disposable);
 }
 
 function deactivate() {}
 
-module.exports = {
-  activate,
-  deactivate,
-};
+module.exports = { activate, deactivate };

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,0 +1,33 @@
+const vscode = require('vscode');
+const axios = require('axios');
+
+async function askAssistant() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showErrorMessage('No active editor.');
+    return;
+  }
+  const selection = editor.selection;
+  const text = editor.document.getText(selection.isEmpty ? undefined : selection);
+  try {
+    const response = await axios.post('http://localhost:8000/query', { code: text });
+    const output = response.data.answer || response.data;
+    const channel = vscode.window.createOutputChannel('Ollama Assistant');
+    channel.appendLine(output);
+    channel.show();
+  } catch (err) {
+    vscode.window.showErrorMessage('Request failed: ' + err.message);
+  }
+}
+
+function activate(context) {
+  let disposable = vscode.commands.registerCommand('ollamaCodeAssistant.ask', askAssistant);
+  context.subscriptions.push(disposable);
+}
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate,
+};

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ollama-code-assistant",
+  "displayName": "Ollama Code Assistant",
+  "description": "Query an Ollama-powered coding assistant from VS Code",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": [
+    "onCommand:ollamaCodeAssistant.ask"
+  ],
+  "main": "extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "ollamaCodeAssistant.ask",
+        "title": "Ask Ollama Assistant"
+      }
+    ]
+  },
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create a FastAPI server exposing an Ollama-based code assistant
- add a minimal VSCode extension that sends selected code to the server
- document how to run the assistant in the README
- update dependencies to include FastAPI and Uvicorn

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8b62a284832ba242ac7275384c27